### PR TITLE
fix: handle default export. fixes #7

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -73,6 +73,10 @@ const loadConfig = async (argv) => {
 
     let configExport = require(resolvedPath); // eslint-disable-line global-require, import/no-dynamic-require
 
+    if (configExport.default) {
+      configExport = configExport.default;
+    }
+
     if (configName) {
       if (!Array.isArray(configExport)) {
         throw new TypeError(

--- a/test/fixtures/webpack.config-default.babel.js
+++ b/test/fixtures/webpack.config-default.babel.js
@@ -1,0 +1,11 @@
+import { resolve } from 'path';
+
+const { error: sterr } = console;
+
+export default {
+  context: __dirname,
+  entry: resolve(__dirname, 'entry.js'),
+  mode: 'development'
+};
+
+sterr('babel-default.js');

--- a/test/test.js
+++ b/test/test.js
@@ -30,6 +30,12 @@ test('babel', async (t) => {
   t.truthy(stderr.includes('⬡ webpack: Build Finished'));
 });
 
+test('babel default export', async (t) => {
+  const { stderr } = await run('--config', 'webpack.config-default.babel.js');
+  t.truthy(stderr.includes('babel-default'));
+  t.truthy(stderr.includes('⬡ webpack: Build Finished'));
+});
+
 test('bad', async (t) => {
   try {
     await run('--config', 'bad.config.js');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [x] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

Issue #7 raised a problem with ES6 module configs that exported a default. The `default` export wasn't recognized and the entire export was passed to webpack, resulting in a validation error. 