### PR TITLE
fix: Fix webpack 5 watch related warning

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -12,6 +12,11 @@ const chalk = require('chalk');
 const webpack = require('webpack');
 
 const run = ({ config, emitJson, watchConfig }, log) => {
+  // Delete possible watch flag from webpack configuration as that triggers a
+  // faulty condition in webpack 5. #20
+  // eslint-disable-next-line no-param-reassign
+  delete config.watch;
+
   let lastHash;
   const compiler = webpack(config);
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -11,6 +11,8 @@
 const chalk = require('chalk');
 const webpack = require('webpack');
 
+const isWebpack5 = () => webpack.version.split('.')[0] === '5';
+
 const run = ({ config, emitJson, watchConfig }, log) => {
   // Delete possible watch flag from webpack configuration as that triggers a
   // faulty condition in webpack 5. #20
@@ -67,9 +69,5 @@ const run = ({ config, emitJson, watchConfig }, log) => {
     compiler.run(done);
   }
 };
-
-const isWebpack5 = () => {
-  return webpack.version.split('.')[0] === '5';
-}
 
 module.exports = { run };

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -14,8 +14,10 @@ const webpack = require('webpack');
 const run = ({ config, emitJson, watchConfig }, log) => {
   // Delete possible watch flag from webpack configuration as that triggers a
   // faulty condition in webpack 5. #20
-  // eslint-disable-next-line no-param-reassign
-  delete config.watch;
+  if (isWebpack5()) {
+    // eslint-disable-next-line no-param-reassign
+    delete config.watch;
+  }
 
   let lastHash;
   const compiler = webpack(config);
@@ -30,7 +32,8 @@ const run = ({ config, emitJson, watchConfig }, log) => {
       return;
     }
 
-    if (lastHash === stats.hash) {
+    // Skip duplicate hash check in webpack 5. #20
+    if (!isWebpack5() && lastHash === stats.hash) {
       log.info(chalk`{dim ⁿᵃⁿᵒ} Duplicate build detected {dim (${lastHash})}\n`);
       return;
     }
@@ -64,5 +67,9 @@ const run = ({ config, emitJson, watchConfig }, log) => {
     compiler.run(done);
   }
 };
+
+function isWebpack5() {
+  return webpack.version.split('.')[0] === '5';
+}
 
 module.exports = { run };

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -68,7 +68,7 @@ const run = ({ config, emitJson, watchConfig }, log) => {
   }
 };
 
-function isWebpack5() {
+const isWebpack5 = () => {
   return webpack.version.split('.')[0] === '5';
 }
 


### PR DESCRIPTION
Closes #40.

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

I changed the code to remove `watch` mode from configuration since watching is extracted by earlier logic already. If this isn't done, then webpack 5 will complain because of a faulty check.

There's still `Duplicate build detected (28144bc52857f5b168c6)` message left but I suspect that might be something else entirely as webpack's watcher was rewritten.

One open question is how to test the change. I could try to set up a separate test with webpack 5 and capture stdin to validate that the warning isn't there anymore for example.